### PR TITLE
Fix Bug when adding coconut variables with $ sign

### DIFF
--- a/src/Coconut.php
+++ b/src/Coconut.php
@@ -33,7 +33,7 @@ class Coconut
         $output = sprintf('-> %s = %s', $format, $this->formatPath($path));
 
         if ($params) {
-            $output .= sprintf(', %s', http_build_query($params, '', ', '));
+            $output .= sprintf(', %s', urldecode(http_build_query($params, '', ', ')));
         }
         
         $this->outputs[] = $output;


### PR DESCRIPTION
Coconut does come with special predefined variables such as $source_width and $source_height ... 
This update prevents php from encoding them.